### PR TITLE
breaking the link to the internal library of nmm. can still import us…

### DIFF
--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -715,4 +715,4 @@ def SaveMaterialsToFile(filename: str, materials: list, format="json") -> str:
 
 # loads the internal material library of materials
 material_dict = {}
-AddMaterialFromDir(Path(__file__).parent / "data", verbose=False)
+#AddMaterialFromDir(Path(__file__).parent / "data", verbose=False)


### PR DESCRIPTION
This removes the auto-load of the internal material library (mostly PNNL compendium) for QA purposes. Users can still import libraries. 